### PR TITLE
Various fixes and changes to slips and stuns

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -39,8 +39,6 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour
 
 	protected GameObject LastDamagedBy;
 
-	private RegisterPlayer registerPlayer;
-	public float StunDuration { get; private set; } = 0;
 
 	public ConsciousState ConsciousState
 	{
@@ -146,7 +144,6 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour
 		DNABloodTypeJSON = JsonUtility.ToJson(DNABloodType);
 		bloodSystem.SetBloodType(DNABloodType);
 		base.OnStartServer();
-		registerPlayer = GetComponent<RegisterPlayer>();
 	}
 
 	public override void OnStartClient()
@@ -348,10 +345,10 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour
 			{
 				tick = 0f;
 				CalculateOverallHealth();
-				CalculateStun();
 			}
 		}
 	}
+
 
 	/// ---------------------------
 	/// VISUAL EFFECTS
@@ -403,26 +400,6 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour
 
 		OverallHealth = newHealth;
 		CheckHealthAndUpdateConsciousState();
-	}
-
-	[Server]
-	protected void CalculateStun(){
-		if(StunDuration > 0)
-		{
-			StunDuration -= 1;
-			if(StunDuration <= 0)
-			{
-				registerPlayer.RemoveStun();
-			}
-		}
-	}
-
-	public void TryChangeStunDuration(float stunDuration)
-	{
-		if (stunDuration > StunDuration)
-		{
-			StunDuration = stunDuration;
-		}
 	}
 
 	int CalculateOverallBodyPartDamage()

--- a/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
@@ -5,7 +5,14 @@ using UnityEngine.Networking;
 
 public class MopTrigger : PickUpTrigger
 {
-    public override bool Interact (GameObject originator, Vector3 position, string hand)
+	private MetaDataLayer metaDataLayer;
+
+	private void Awake()
+	{
+		metaDataLayer = transform.GetComponentInParent<MetaDataLayer>();
+	}
+
+	public override bool Interact (GameObject originator, Vector3 position, string hand)
     {
         //TODO:  Fill this in.
 
@@ -48,7 +55,11 @@ public class MopTrigger : PickUpTrigger
 
 	    if (!MatrixManager.IsSpaceAt(targetWorldIntPos) )
 	    {
-		    EffectsFactory.Instance.WaterSplat(targetWorldIntPos);
+		    // Create a WaterSplat Decal (visible slippery tile)
+		    // EffectsFactory.Instance.WaterSplat(targetWorldIntPos);
+
+		    // Sets a tile to slippery
+		    metaDataLayer.MakeSlipperyAt(targetWorldIntPos);
 	    }
     }
 }

--- a/UnityProject/Assets/Scripts/Player/CrossedBehaviors/Slippery.cs
+++ b/UnityProject/Assets/Scripts/Player/CrossedBehaviors/Slippery.cs
@@ -13,17 +13,21 @@ public class Slippery : MonoBehaviour
 
 	private void OnEnable()
 	{
-		registerItem.OnCrossed += Slip;
+		registerItem.OnCrossed.AddListener(Slip);
 	}
 
 	private void OnDisable()
 	{
-		registerItem.OnCrossed -= Slip;
+		registerItem.OnCrossed.RemoveListener(Slip);
 	}
 
 	private void Slip()
 	{
-		registerItem.CrossedRegisterPlayer.Stun(4f);
+		if (MatrixManager.IsSpaceAt(transform.position.CutToInt()))
+		{
+			return;
+		}
+		registerItem.CrossedRegisterPlayer.Stun();
 		SoundManager.PlayNetworkedAtPos("Slip", transform.position);
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -37,6 +37,8 @@ public partial class PlayerSync
 	/// Last direction that player moved in. Currently works more like a true impulse, therefore is zero-able
 	private Vector2 serverLastDirection;
 
+	private RegisterPlayer registerPlayer;
+
 	public float SpeedServer
 	{
 		get => masterSpeedServer;
@@ -80,6 +82,7 @@ public partial class PlayerSync
 		{
 			base.OnStartServer();
 			InitServerState();
+			registerPlayer = GetComponent<RegisterPlayer>();
 		}
 
 	///
@@ -609,6 +612,8 @@ public partial class PlayerSync
 
 	private void Cross(Vector3Int position)
 	{
+		registerPlayer.CheckTileSlip();
+
 		if (PlayerUtils.IsGhost(gameObject))
 		{
 			return;
@@ -616,10 +621,9 @@ public partial class PlayerSync
 		List<GameObject> objects = UITileList.GetItemsAtPosition(position);
 		// Removes player from object list
 		objects.Remove(gameObject);
-		RegisterPlayer registerPlayer = GetComponent<RegisterPlayer>();
 		for (int i = 0; i < objects.Count; i++)
 		{
-			objects[i].GetComponent<RegisterItem>()?.Cross(ref registerPlayer);
+			objects[i].GetComponent<RegisterItem>()?.Cross(registerPlayer);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
@@ -56,6 +57,30 @@ public class MetaDataLayer : MonoBehaviour
 	{
 		return Get(position, false).Exists;
 	}
+
+	public bool IsSlipperyAt(Vector3Int position)
+	{
+		return Get(position, false).IsSlippery;
+	}
+
+	public void MakeSlipperyAt(Vector3Int position)
+	{
+		var tile = Get(position);
+		tile.IsSlippery = true;
+		if (tile.CurrentDrying != null)
+		{
+			StopCoroutine(tile.CurrentDrying);
+		}
+		tile.CurrentDrying = DryUp(tile);
+		StartCoroutine(tile.CurrentDrying);
+	}
+
+	private IEnumerator DryUp(MetaDataNode tile)
+	{
+		yield return new WaitForSeconds(15f);
+		tile.IsSlippery = false;
+	}
+
 
 	public void UpdateSystemsAt(Vector3Int position)
 	{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Atmospherics;
@@ -57,6 +58,11 @@ public class MetaDataNode: IGasMixContainer
 	}
 
 	/// <summary>
+	/// Current drying coroutine.
+	/// </summary>
+	public IEnumerator CurrentDrying;
+
+	/// <summary>
 	/// The current neighbor nodes. Nodes can be Null!
 	/// </summary>
 	public readonly MetaDataNode[] Neighbors = new MetaDataNode[4];
@@ -94,6 +100,8 @@ public class MetaDataNode: IGasMixContainer
 	/// Is this tile occupied by something impassable
 	/// </summary>
 	public bool IsOccupied => Type == NodeType.Occupied;
+
+	public bool IsSlippery = false;
 
 	public bool Exists => this != None;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterItem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterItem.cs
@@ -7,13 +7,12 @@ using UnityEngine.Serialization;
 [ExecuteInEditMode]
 	public class RegisterItem : RegisterTile
 	{
-		public delegate void Crossed();
-		public event Crossed OnCrossed;
+		public UnityEvent OnCrossed;
 
 		[HideInInspector]
 		public RegisterPlayer CrossedRegisterPlayer;
 
-		public void Cross(ref RegisterPlayer registerPlayer)
+		public void Cross(RegisterPlayer registerPlayer)
 		{
 			CrossedRegisterPlayer = registerPlayer;
 			OnCrossed?.Invoke();


### PR DESCRIPTION
Made object dropping optional.
Moved the registerPlayer cache to the start in PlayerSync.server.cs.
Removed ref in RegisterItem.cs.
Changed event in RegisterItem.cs to a unityevent.
No longer slip on banana peels in space.
Moved stuns out of LivingHealthBehaviour, stuns are now entirely in RegisterPlayer.cs.
Disabled wet floor decal and replaced it with a IsSlippery boolean in the tile's MetaData.