### PR TITLE
Various changes

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
@@ -7,11 +7,6 @@ public class MopTrigger : PickUpTrigger
 {
 	private MetaDataLayer metaDataLayer;
 
-	private void Awake()
-	{
-		metaDataLayer = transform.GetComponentInParent<MetaDataLayer>();
-	}
-
 	public override bool Interact (GameObject originator, Vector3 position, string hand)
     {
         //TODO:  Fill this in.
@@ -44,22 +39,30 @@ public class MopTrigger : PickUpTrigger
         return base.Interact (originator, position, hand);
     }
 
-    public void CleanTile (Vector3 spatsPos)
+    public void CleanTile (Vector3 worldPos)
     {
-	    Vector3Int targetWorldIntPos = spatsPos.CutToInt();
-	    var floorDecals = MatrixManager.GetAt<FloorDecal>(targetWorldIntPos);
+	    var worldPosInt = worldPos.CutToInt();
+	    var matrix = MatrixManager.AtPoint( worldPosInt );
+	    var localPosInt = MatrixManager.WorldToLocalInt( worldPos, matrix );
+	    var floorDecals = MatrixManager.GetAt<FloorDecal>(worldPosInt);
+
 	    for ( var i = 0; i < floorDecals.Count; i++ )
 	    {
 		    floorDecals[i].DisappearFromWorldServer();
 	    }
 
-	    if (!MatrixManager.IsSpaceAt(targetWorldIntPos) )
+	    if (!MatrixManager.IsSpaceAt(worldPosInt))
 	    {
 		    // Create a WaterSplat Decal (visible slippery tile)
 		    // EffectsFactory.Instance.WaterSplat(targetWorldIntPos);
 
 		    // Sets a tile to slippery
-		    metaDataLayer.MakeSlipperyAt(targetWorldIntPos);
+		    matrix.MetaDataLayer.MakeSlipperyAt(localPosInt);
+		    Debug.Log($"Hamish: MopTrigger.CleanTile() at" +
+		              $"matrix.MetaDataLayer at local: X:{localPosInt.x} Y:{localPosInt.y} " +
+		              $"Matrix at world: X:{worldPosInt.x} Y:{worldPosInt.y} ID: {matrix.Id}. " +
+		              $"IsSlippery = {matrix.MetaDataLayer.IsSlipperyAt(localPosInt)}");
 	    }
+
     }
 }

--- a/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
@@ -43,7 +43,7 @@ public class MopTrigger : PickUpTrigger
     {
 	    var worldPosInt = worldPos.CutToInt();
 	    var matrix = MatrixManager.AtPoint( worldPosInt );
-	    var localPosInt = MatrixManager.WorldToLocalInt( worldPos, matrix );
+	    var localPosInt = MatrixManager.WorldToLocalInt( worldPosInt, matrix );
 	    var floorDecals = MatrixManager.GetAt<FloorDecal>(worldPosInt);
 
 	    for ( var i = 0; i < floorDecals.Count; i++ )
@@ -58,10 +58,6 @@ public class MopTrigger : PickUpTrigger
 
 		    // Sets a tile to slippery
 		    matrix.MetaDataLayer.MakeSlipperyAt(localPosInt);
-		    Debug.Log($"Hamish: MopTrigger.CleanTile() at" +
-		              $"matrix.MetaDataLayer at local: X:{localPosInt.x} Y:{localPosInt.y} " +
-		              $"Matrix at world: X:{worldPosInt.x} Y:{worldPosInt.y} ID: {matrix.Id}. " +
-		              $"IsSlippery = {matrix.MetaDataLayer.IsSlipperyAt(localPosInt)}");
 	    }
 
     }

--- a/UnityProject/Assets/Scripts/Player/CrossedBehaviors/Slippery.cs
+++ b/UnityProject/Assets/Scripts/Player/CrossedBehaviors/Slippery.cs
@@ -13,21 +13,21 @@ public class Slippery : MonoBehaviour
 
 	private void OnEnable()
 	{
-		registerItem.OnCrossed.AddListener(Slip);
+		registerItem.crossed.AddListener(Slip);
 	}
 
 	private void OnDisable()
 	{
-		registerItem.OnCrossed.RemoveListener(Slip);
+		registerItem.crossed.RemoveListener(Slip);
 	}
 
-	private void Slip()
+	private void Slip(RegisterPlayer registerPlayer)
 	{
-		if (MatrixManager.IsSpaceAt(transform.position.CutToInt()))
+		if (MatrixManager.IsSpaceAt(registerItem.WorldPosition))
 		{
 			return;
 		}
-		registerItem.CrossedRegisterPlayer.Stun();
-		SoundManager.PlayNetworkedAtPos("Slip", transform.position);
+		registerPlayer.Stun();
+		SoundManager.PlayNetworkedAtPos("Slip", registerItem.Position);
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -612,18 +612,18 @@ public partial class PlayerSync
 
 	private void Cross(Vector3Int position)
 	{
-		registerPlayer.CheckTileSlip();
+		CheckTileSlip();
 
 		if (PlayerUtils.IsGhost(gameObject))
 		{
 			return;
 		}
-		List<GameObject> objects = UITileList.GetItemsAtPosition(position);
+		List<RegisterItem> objects = MatrixManager.GetAt<RegisterItem>(position);
 		// Removes player from object list
-		objects.Remove(gameObject);
+		objects.Remove(gameObject.GetComponent<RegisterItem>());
 		for (int i = 0; i < objects.Count; i++)
 		{
-			objects[i].GetComponent<RegisterItem>()?.Cross(registerPlayer);
+			objects[i].Cross(registerPlayer);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -626,4 +626,16 @@ public partial class PlayerSync
 			objects[i].Cross(registerPlayer);
 		}
 	}
+
+	public void CheckTileSlip()
+	{
+		var worldPosition = serverState.WorldPosition.CutToInt();
+		var position = serverState.Position.CutToInt();
+		var matrix = MatrixManager.Get(serverState.MatrixId);
+
+		if (matrix.MetaDataLayer.IsSlipperyAt(position))
+		{
+			registerPlayer.Stun();
+		}
+	}
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -408,24 +408,6 @@ public partial class PlayerSync : NetworkBehaviour, IPushable
 		CmdProcessAction(action);
 	}
 
-	public void CheckTileSlip()
-	{
-		var WorldPosition = serverState.WorldPosition.CutToInt();
-		var Position = serverState.Position.CutToInt();
-
-		var matrix = MatrixManager.Get(serverState.MatrixId);
-		Debug.Log($"Hamish: RegisterPlayer.CheckTileSlip() at matrix.MetaDataLayer at local:" +
-		          $"X:{Position.x} Y:{Position.y} Matrix at world: X:{WorldPosition.x} Y:{WorldPosition.y} ID: {matrix.Id}." +
-		          $" IsSlippery = {matrix.MetaDataLayer.IsSlipperyAt(Position)}");
-
-		if (matrix.MetaDataLayer.IsSlipperyAt(Position))
-		{
-			Debug.Log("Hamish: RegisterPlayer tile IsSlippery!!!");
-			registerPlayer.Stun();
-		}
-	}
-
-
 #if UNITY_EDITOR
 	//Visual debug
 	[NonSerialized]

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -408,6 +408,24 @@ public partial class PlayerSync : NetworkBehaviour, IPushable
 		CmdProcessAction(action);
 	}
 
+	public void CheckTileSlip()
+	{
+		var WorldPosition = serverState.WorldPosition.CutToInt();
+		var Position = serverState.Position.CutToInt();
+
+		var matrix = MatrixManager.Get(serverState.MatrixId);
+		Debug.Log($"Hamish: RegisterPlayer.CheckTileSlip() at matrix.MetaDataLayer at local:" +
+		          $"X:{Position.x} Y:{Position.y} Matrix at world: X:{WorldPosition.x} Y:{WorldPosition.y} ID: {matrix.Id}." +
+		          $" IsSlippery = {matrix.MetaDataLayer.IsSlipperyAt(Position)}");
+
+		if (matrix.MetaDataLayer.IsSlipperyAt(Position))
+		{
+			Debug.Log("Hamish: RegisterPlayer tile IsSlippery!!!");
+			registerPlayer.Stun();
+		}
+	}
+
+
 #if UNITY_EDITOR
 	//Visual debug
 	[NonSerialized]

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -79,6 +79,7 @@ public class MetaDataLayer : MonoBehaviour
 	{
 		yield return new WaitForSeconds(15f);
 		tile.IsSlippery = false;
+		Debug.Log($"Hamish: wet floor dried up at X:{tile.Position.x} Y:{tile.Position.y}");
 	}
 
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterItem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterItem.cs
@@ -3,19 +3,17 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Serialization;
 
+[System.Serializable]
+public class OnCrossed : UnityEvent<RegisterPlayer>{};
 
 [ExecuteInEditMode]
 	public class RegisterItem : RegisterTile
 	{
-		public UnityEvent OnCrossed;
-
-		[HideInInspector]
-		public RegisterPlayer CrossedRegisterPlayer;
+		public OnCrossed crossed;
 
 		public void Cross(RegisterPlayer registerPlayer)
 		{
-			CrossedRegisterPlayer = registerPlayer;
-			OnCrossed?.Invoke();
+			crossed.Invoke(registerPlayer);
 		}
 
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -152,14 +152,6 @@ public class RegisterPlayer : RegisterTile
 		}
 	}
 
-	public void CheckTileSlip()
-	{
-		if (metaDataLayer.IsSlipperyAt(transform.position.CutToInt()))
-		{
-			Stun();
-		}
-	}
-
 	public void Stun(float stunDuration = 4f, bool dropItem = true)
 	{
 		isStunned = true;


### PR DESCRIPTION
In RegisterItem.cs changed OnCrossed unity event to use a RegisterPlayer parameter.
In RegisterPlayer.cs used correct Position Vector3Int for CheckTileSlip().
In Slippery.cs used registerItem's world position instead of calling transform.position.
In PlayerSync.Server.cs in Cross(position) used MatrixManager to get the items at a position instead of UITileList.
Moved CheckTileSlip to PlayerSync.Server.cs.