### PR TITLE
Various changes

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -679,12 +679,6 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour
 			OverallHealth = maxHealth;
 		}
 	}
-
-	/// <summary>
-	/// Recalculates the stun duration and updates its state. Server only
-	/// </summary>
-
-
 }
 
 public static class HealthThreshold

--- a/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
@@ -5,8 +5,6 @@ using UnityEngine.Networking;
 
 public class MopTrigger : PickUpTrigger
 {
-	private MetaDataLayer metaDataLayer;
-
 	public override bool Interact (GameObject originator, Vector3 position, string hand)
     {
         //TODO:  Fill this in.

--- a/UnityProject/Assets/Scripts/Player/CrossedBehaviors/Slippery.cs
+++ b/UnityProject/Assets/Scripts/Player/CrossedBehaviors/Slippery.cs
@@ -5,10 +5,12 @@ using UnityEngine;
 public class Slippery : MonoBehaviour
 {
 	private RegisterItem registerItem;
+	private CustomNetTransform customNetTransform;
 
 	private void Awake()
 	{
 		registerItem = GetComponent<RegisterItem>();
+		customNetTransform = GetComponent<CustomNetTransform>();
 	}
 
 	private void OnEnable()
@@ -23,11 +25,11 @@ public class Slippery : MonoBehaviour
 
 	private void Slip(RegisterPlayer registerPlayer)
 	{
-		if (MatrixManager.IsSpaceAt(registerItem.WorldPosition))
+		if (MatrixManager.IsSpaceAt(registerItem.WorldPosition) || customNetTransform.IsBeingThrown)
 		{
 			return;
 		}
-		registerPlayer.Stun();
-		SoundManager.PlayNetworkedAtPos("Slip", registerItem.Position);
+		registerPlayer.Slip();
+		SoundManager.PlayNetworkedAtPos("Slip", registerItem.WorldPosition);
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -629,13 +629,12 @@ public partial class PlayerSync
 
 	public void CheckTileSlip()
 	{
-		var worldPosition = serverState.WorldPosition.CutToInt();
 		var position = serverState.Position.CutToInt();
 		var matrix = MatrixManager.Get(serverState.MatrixId);
 
 		if (matrix.MetaDataLayer.IsSlipperyAt(position))
 		{
-			registerPlayer.Stun();
+			registerPlayer.Slip();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -79,7 +79,6 @@ public class MetaDataLayer : MonoBehaviour
 	{
 		yield return new WaitForSeconds(15f);
 		tile.IsSlippery = false;
-		Debug.Log($"Hamish: wet floor dried up at X:{tile.Position.x} Y:{tile.Position.y}");
 	}
 
 


### PR DESCRIPTION
In MetaDataLayer.cs removed Debug.Log() that was left in.
In MopTrigger.cs removed metaDataLayer field.
In Slippery.cs changed the audio to play at a WorldPosition instead of a localPosition.
In PlayerSync.Server.cs removed the "worldPosition" definition as it was unused.
In LivingHealthBehaviour.cs removed dangling summary.
In RegisterPlayer.cs changed stun timer from using the update manager to a coroutine.
In RegisterPlayer.cs made the Slip() method and changed Stun()'s calls to call Slip(). Slip() contains logic to prevent slipping while walking then calls Stun().
In Slippery.cs added a check to Slip() that the item isn't being thrown before slipping the player.